### PR TITLE
fix: python3 path may not be correctly configured

### DIFF
--- a/get_all_locations.sh
+++ b/get_all_locations.sh
@@ -1,9 +1,11 @@
 #! /bin/bash
 
 git_upload="$(jq '.git_upload' settings.json)"
+python3_exe="$(jq '.python3_executable' settings.json)"
+
 
 jq '.[].id' docs/centers.json \
-  | parallel "./scrape_availability.py {} results.json || echo {} >> errors.txt"
+  | parallel $python3_exe "./scrape_availability.py {} results.json || echo {} >> errors.txt"
 
 ERR_NUM="$(wc -l < errors.txt)"
 

--- a/settings_sample.json
+++ b/settings_sample.json
@@ -1,9 +1,10 @@
 {
-  "username":"your_user_name",
-  "password":"your_password",
+  "username": "your_user_name",
+  "password": "your_password",
+  "python3_executable": "python3",
   "have_booking": false,
   "headless": true,
   "git_upload": false,
   "wait_timer": 2,
-  "wait_timer_car": 15,
+  "wait_timer_car": 15
 }


### PR DESCRIPTION
added an option in settings.json for user to specify python executable binary location

Some systems may have `python` as executable name while other may have `python3` or some other specific paths of python binary like `/usr/bin/python3`

